### PR TITLE
chore/update keybindings

### DIFF
--- a/keybinding.jsonc
+++ b/keybinding.jsonc
@@ -9,6 +9,10 @@
     "key": "ctrl+w",
     "command": "workbench.action.quickSwitchWindow"
   },
+  {
+    "key": "alt+a",
+    "command": "editor.emmet.action.wrapWithAbbreviation"
+  },
 
   // ========== for Cursor 🤖 ==========
   {

--- a/keybinding.jsonc
+++ b/keybinding.jsonc
@@ -16,7 +16,7 @@
     "command": "workbench.action.closeEditorsInGroup"
   },
   {
-    "key": "cmd+k",
+    "key": "cmd+r",
     "command": "cursorai.action.generateInTerminal"
   },
 ]


### PR DESCRIPTION
Closes #18
Closes #20

- **update keybinding for terminal generation command**
- **add keybinding for Emmet wrap with abbreviation**
