### PR TITLE
clean extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
     "artdiniz.quitcontrol-vscode",
     "jock.svg",
     "iconify.iconify",
+    "vsls-contrib.codetour",
 
     // I'm not sure it works with Japanese 🫠
     "yoavbls.pretty-ts-errors",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,8 +15,6 @@
 
     // ========== Now I'm Trying ⬇️ ==========
     "VisualStudioExptTeam.vscodeintellicode",
-    "wix.vscode-import-cost",
-    "WallabyJs.console-ninja",
     "ChakrounAnas.turbo-console-log",
     "rooveterinaryinc.roo-cline",
     "pflannery.vscode-versionlens",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,10 @@
     "iconify.iconify",
     "vsls-contrib.codetour",
 
+    // Themes
+    "Catppuccin.catppuccin-vsc",
+    "Catppuccin.catppuccin-vsc-icons",
+
     // I'm not sure it works with Japanese 🫠
     "yoavbls.pretty-ts-errors",
 


### PR DESCRIPTION
Closes #46

- **chore: remove unused VSCode extensions from configuration**
- **chore: add CodeTour extension to VSCode configuration**
- **chore: add Catppuccin theme extensions to VSCode configuration**
