### PR TITLE
feat: update Claude Code config to use terminal mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -253,6 +253,7 @@
   "prettier.enable": false,
 
   "claudeCode.preferredLocation": "panel",
+  "claudeCode.useTerminal": true,
 
   // ========== Draw.io ==========
   // For my job 👔

--- a/keybinding.jsonc
+++ b/keybinding.jsonc
@@ -25,6 +25,6 @@
   },
   {
     "key": "ctrl+escape",
-    "command": "claude-vscode.editor.open"
+    "command": "claude-vscode.terminal.open"
   }
 ]


### PR DESCRIPTION
## Summary
- Change `ctrl+escape` keybinding from `claude-vscode.editor.open` to `claude-vscode.terminal.open`
- Add `claudeCode.useTerminal: true` setting

Closes #79

## Test plan
- [ ] Verify `ctrl+escape` opens Claude Code in terminal mode
- [ ] Confirm settings are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)